### PR TITLE
[WIP] Add Request model

### DIFF
--- a/app/assets/javascripts/requests.coffee
+++ b/app/assets/javascripts/requests.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/requests.scss
+++ b/app/assets/stylesheets/requests.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Requests controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
     redirect_to root_path unless current_user&.admin?
   end
 
+  def check_customer_access
+    redirect_to root_path unless current_user&.customer?
+  end
+
   def check_full_access
     redirect_to root_path unless current_user&.manager? || current_user&.admin?
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,0 +1,66 @@
+class RequestsController < ApplicationController
+  before_action :check_customer_access, only: %i[new create]
+  before_action :check_full_access, only: %i[update edit destroy]
+  before_action :set_request, only: %i[show edit update destroy]
+
+  def index
+    @requests = RequestService.new(current_user).call
+  end
+
+  def show; end
+
+  def new
+    @request = Request.new
+  end
+
+  def edit; end
+
+  def create
+    new_request
+    respond_to do |format|
+      if @request.save
+        format.html { redirect_to @request, notice: 'Request was successfully created.' }
+        format.json { render :show, status: :created, location: @request }
+      else
+        format.html { render :new }
+        format.json { render json: @request.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    @request.user = current_user
+    respond_to do |format|
+      if @request.update(request_params)
+        format.html { redirect_to @request, notice: 'Request was successfully updated.' }
+        format.json { render :show, status: :ok, location: @request }
+      else
+        format.html { render :edit }
+        format.json { render json: @request.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @request.destroy
+    respond_to do |format|
+      format.html { redirect_to requests_url, notice: 'Request was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def new_request
+    @request = Request.new(request_params)
+    @request.user = current_user
+  end
+
+  def set_request
+    @request = Request.find(params[:id])
+  end
+
+  def request_params
+    params.require(:request).permit(:status, :user_id, :timeslot_id)
+  end
+end

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -1,0 +1,2 @@
+module RequestsHelper
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,0 +1,9 @@
+class Request < ApplicationRecord
+  belongs_to :user
+  belongs_to :timeslot
+
+  STATUS = %w[initiated approved declined cancelled completed].freeze
+  enum status: STATUS
+
+  validates :status, presence: true, inclusion: { in: STATUS }
+end

--- a/app/models/timeslot.rb
+++ b/app/models/timeslot.rb
@@ -1,5 +1,6 @@
 class Timeslot < ApplicationRecord
   belongs_to :district
+  has_many :requests
   belongs_to :user, -> { User.manager }, inverse_of: false, optional: false
   validates :start_time, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
 
   has_one :account
   has_many :timeslots
+  has_many :requests
 
   EMAIL_LENGTH = (6..50).freeze
   ROLES = %w[customer manager admin].freeze

--- a/app/services/request_service.rb
+++ b/app/services/request_service.rb
@@ -7,7 +7,8 @@ class RequestService
     if @user&.admin?
       Request.all
     elsif @user&.manager?
-      @user.requests
+      request = @user.timeslots.map { |t| t.requests.map { |r| r } }
+      request.flatten
     elsif @user&.customer?
       @user.requests
     end

--- a/app/services/request_service.rb
+++ b/app/services/request_service.rb
@@ -1,0 +1,15 @@
+class RequestService
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    if @user&.admin?
+      Request.all
+    elsif @user&.manager?
+      @user.requests
+    elsif @user&.customer?
+      @user.requests
+    end
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,7 +19,7 @@
         <h2>Make Earth clean again!</h2>
 
         <% if user_signed_in? %>
-          <%= link_to 'Request', '', class: 'btn btn-warning' %>
+          <%= link_to 'Request', new_request_path, class: 'btn btn-warning' %>
         <% else %>
           <%= link_to 'Log In', new_user_session_path, class: 'btn btn-warning' %>
           <%= link_to 'Sign Up', new_user_registration_path, class: 'btn btn-warning' %>

--- a/app/views/requests/_form.html.erb
+++ b/app/views/requests/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with(model: request, local: true) do |form| %>
+  <% if request.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(request.errors.count, "error") %> prohibited this request from being saved:</h2>
+
+      <ul>
+      <% request.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.hidden_field :status %>
+  </div>
+  <div class="field">
+  <%= form.label :timeslot %>
+  <%= form.collection_select(:timeslot_id, Timeslot.all, :id, :start_time)
+  %>
+</div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/requests/_request.json.jbuilder
+++ b/app/views/requests/_request.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! request, :id, :status, :created_at, :updated_at
+json.url request_url(request, format: :json)

--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Request</h1>
+
+<%= render 'form', request: @request %>
+
+<%= link_to 'Show', @request %> |
+<%= link_to 'Back', requests_path %>

--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -1,6 +1,32 @@
 <h1>Editing Request</h1>
 
-<%= render 'form', request: @request %>
+<%= form_with(model: @request, local: true) do |form| %>
+  <% if @request.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@request.errors.count, "error") %> prohibited this request from being saved:</h2>
+
+      <ul>
+      <% @request.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.text_field :status %>
+  </div>
+  <div class="field">
+  <%= form.label :timeslot %>
+  <%= form.collection_select(:timeslot_id, Timeslot.all, :id, :start_time)
+  %>
+</div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>
+
 
 <%= link_to 'Show', @request %> |
 <%= link_to 'Back', requests_path %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Requests</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Status</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @requests.each do |request| %>
+      <tr>
+        <td><%= request.status %></td>
+        <td><%= link_to 'Show', request %></td>
+        <td><%= link_to 'Edit', edit_request_path(request) %></td>
+        <td><%= link_to 'Destroy', request, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Request', new_request_path %>

--- a/app/views/requests/index.json.jbuilder
+++ b/app/views/requests/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @requests, partial: "requests/request", as: :request

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Request</h1>
+
+<%= render 'form', request: @request %>
+
+<%= link_to 'Back', requests_path %>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Status:</strong>
+  <%= @request.status %>
+</p>
+
+<%= link_to 'Edit', edit_request_path(@request) %> |
+<%= link_to 'Back', requests_path %>

--- a/app/views/requests/show.json.jbuilder
+++ b/app/views/requests/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "requests/request", request: @request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :requests
   resources :timeslots
   resources :contacts, except: :show
   resources :abouts, only: %i[index edit update]

--- a/db/migrate/20190724184626_create_requests.rb
+++ b/db/migrate/20190724184626_create_requests.rb
@@ -1,0 +1,11 @@
+class CreateRequests < ActiveRecord::Migration[5.2]
+  def change
+    create_table :requests do |t|
+      t.integer :status, null: false, default: 0
+      t.belongs_to :timeslot, index: true
+      t.belongs_to :user, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_141901) do
+ActiveRecord::Schema.define(version: 2019_07_24_184626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,16 @@ ActiveRecord::Schema.define(version: 2019_07_16_141901) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["city_id"], name: "index_districts_on_city_id"
+  end
+
+  create_table "requests", force: :cascade do |t|
+    t.integer "status", default: 0, null: false
+    t.bigint "timeslot_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["timeslot_id"], name: "index_requests_on_timeslot_id"
+    t.index ["user_id"], name: "index_requests_on_user_id"
   end
 
   create_table "timeslots", force: :cascade do |t|

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe RequestsController, type: :controller do
+  let(:valid_session) { {} }
+
+  let(:request_valid_status) do
+    { status: 'initiated' }
+  end
+
+  let(:request_invalid_status) do
+    status { ' ' }
+  end
+  let(:user_customer) { FactoryBot.create(:user_customer) }
+  let(:user_manager) { FactoryBot.create(:user_manager) }
+  let(:user_admin) { FactoryBot.create(:user_admin) }
+  let(:timeslot) { FactoryBot.create(:timeslot_valid_time) }
+  let(:request) { FactoryBot.create(:request_valid_status) }
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      get :show, params: { id: request.to_param }, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      get :edit, params: { id: request.to_param }, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new Request' do
+        expect do
+          post :create, params: { request: request_valid_status }, session: valid_session
+        end.to change(Request, :count).by(1)
+      end
+
+      it 'redirects to the created request' do
+        post :create, params: { request: request_valid_status }, session: valid_session
+        expect(response).to redirect_to(Request.last)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { request: request_valid_status }, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        skip('Add a hash of attributes valid for your model')
+      end
+
+      it 'updates the requested request' do
+        put :update, params: { id: request.to_param, request: request_valid_status }, session: valid_session
+        request.reload
+      end
+
+      it 'redirects to the request' do
+        put :update, params: { id: request.to_param, request: request_valid_status }, session: valid_session
+        expect(response).to redirect_to(request)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        put :update, params: { id: request.to_param, request: request_valid_status }, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested request' do
+      expect do
+        delete :destroy, params: { id: request.to_param }, session: valid_session
+      end.to change(Request, :count).by(-1)
+    end
+
+    it 'redirects to the requests list' do
+      delete :destroy, params: { id: request.to_param }, session: valid_session
+      expect(response).to redirect_to(requests_url)
+    end
+  end
+end

--- a/spec/factories/requests_factory.rb
+++ b/spec/factories/requests_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :request do
+    association :timeslot, factory: :timeslot_valid_time
+    association :user, factory: :user
+    factory :request_valid_status do
+      status { 'initiated' }
+    end
+    factory :request_invalid_status do
+      status { ' ' }
+    end
+  end
+end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Request, type: :model do
+  context 'validations' do
+    let(:status) { FactoryBot.create(:request_valid_status) }
+    it 'is valid with valid attributes' do
+      request = FactoryBot.build(:request_valid_status)
+      expect(request).to be_valid
+    end
+  end
+end

--- a/spec/models/timeslot_spec.rb
+++ b/spec/models/timeslot_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Timeslot, type: :model do
   context 'validations' do
-    let(:timeslot) { FactoryBot.create(:valid_time) }
+    let(:timeslot) { FactoryBot.create(:timeslot_valid_time) }
     it 'is valid with valid attributes' do
       timeslot = FactoryBot.build(:timeslot_valid_time)
       expect(timeslot).to be_valid


### PR DESCRIPTION
- status - default value initiated, Manager can approve Request (status
changed to approved) and decline Request (status changed to declined).
Customer can cancel Request (cancelled). Approved request can be
completed.

Customers can has many Requests
Timeslot can has many Requests, but not more then 3.(don't create now)

On index page:
1) for managers - list of all requests of this manager.
2) for customers - list of all his requests
3) admin can see all requests

New action available only for Customers.
Update action should be used to change Request status